### PR TITLE
Logfile Encoding, Disable HTTP Auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ bin/weechat-log-server`. All args are optional, but setting -p is recommended.
     -c, --cache-directory DIR        Cache directory (default: cache)
     -P, --port PORT                  HTTP server port (default: 4567)
     -b, --bind-address IP            HTTP server listen IP (default: 0.0.0.0)
+    -N, --no-auth                    Don't use HTTP authentication.
     -u, --user-name USER             User name to access logs. (default: admin)
     -p, --password PASSWORD          Password to access logs. (default: admin)
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ bin/weechat-log-server`. All args are optional, but setting -p is recommended.
     -v, --verbose                    Output a lot of information.
     -d, --weechat-directory DIR      WeeChat's log directory (default: ~/.weechat/logs/)
     -r, --regex REGEX                Regular expression to match file names. (default: (?-mix:irc\.(?<network>[^\.]+)\.(?<buffer>[^\.]+)\.weechatlog))
+    -e, --encoding ENCODING          Encoding of the logs. (default: UTF-8, old: ASCII-8BIT)
     -t, --templates-directory DIR    Sinatra templates directory (default: views)
     -c, --cache-directory DIR        Cache directory (default: cache)
     -P, --port PORT                  HTTP server port (default: 4567)

--- a/bin/weechat-log-server
+++ b/bin/weechat-log-server
@@ -51,6 +51,11 @@ OptionParser.new do |opts|
     $opts[:bind_address] = opt
   end
 
+  $opts[:no_auth] = false
+  opts.on '-N', '--no-auth', "Don't use HTTP authentication." do |opt|
+    $opts[:no_auth] = true
+  end
+
   $opts[:user_name] = 'admin'
   opts.on '-u', '--user-name USER', "User name to access logs. (default: #{$opts[:user_name]})" do |opt|
     $opts[:user_name] = opt

--- a/bin/weechat-log-server
+++ b/bin/weechat-log-server
@@ -26,6 +26,11 @@ OptionParser.new do |opts|
     $opts[:file_name_regex] = opt
   end
 
+  $opts[:encoding] = 'UTF-8'
+  opts.on '-e', '--encoding ENCODING', "Encoding of the logs. (default: #{$opts[:encoding]}, old: ASCII-8BIT)" do |opt|
+    $opts[:encoding] = opt
+  end
+
   $opts[:templates_dir] = 'views'
   opts.on '-t', '--templates-directory DIR', "Sinatra templates directory (default: #{$opts[:templates_dir]})" do |opt|
     $opts[:templates_dir] = opt

--- a/lib/weechat-log-server/string.rb
+++ b/lib/weechat-log-server/string.rb
@@ -1,6 +1,6 @@
 class String
   def fix_encoding!
-    encode! 'ASCII-8BIT',
+    encode! $opts[:encoding],
       :invalid => :replace,
       :undef   => :replace
   end

--- a/lib/weechat-log-server/webserver.rb
+++ b/lib/weechat-log-server/webserver.rb
@@ -29,7 +29,7 @@ class Webserver < Sinatra::Base
   helpers do
 
     def auth_required!
-      unless authorized?
+      unless $opts[:no_auth] || authorized?
         response['WWW-Authenticate'] = %(Basic realm="Restricted Area")
         throw :halt, [401, "Not authorized\n"]
       end


### PR DESCRIPTION
I wrote two changes for your software:
1. encoding of logfiles is changeable by flag
2. default changed from ASCII to UTF-8 (because Weechat did so)
3. added flag to disable HTTP authentication
